### PR TITLE
Add CORS and fix on jsonpickle library

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from flask import Flask, g, \
     jsonify, make_response, redirect, render_template, render_template_string, \
     request, safe_join, send_file, send_from_directory, session, url_for
 from flask_caching import Cache
+from flask_cors import CORS
 from http import HTTPStatus
 from pathlib import Path
 from richcontext import server as rc_server
@@ -317,6 +318,8 @@ class RCServerApp (Flask):
 
 APP = RCServerApp(__name__)
 CACHE = Cache(APP, config={"CACHE_TYPE": "simple"})
+CORS(APP)
+
 
 
 ######################################################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ pytest >= 4.1.1
 pyvis >= 0.1.7.0
 qrcode >= 6.0
 scipy >= 1.4.1
+jsonpickle >= 1.4.1
+flask-cors >= 3.0.8


### PR DESCRIPTION
The RC Server is currently blocking request from the Data Stewardship app (alloy/vision) due to CORS policy. I added the flask-cors library and plugged in the Flask instance.

I had a problem to run this project, couldn't start the server because of **jsonpickle** import error in one dependency. To fix this I added the **jsonpickle** library on the **requirements.txt.**